### PR TITLE
Cleaning up the colors for accessibility

### DIFF
--- a/docs/user_guide/customizing.rst
+++ b/docs/user_guide/customizing.rst
@@ -7,6 +7,13 @@ Customizing the theme
 In addition to the configuration options detailed at :ref:`configuration`, it
 is also possible to customize the HTML layout and CSS style of the theme.
 
+.. danger::
+
+    This theme is still under active development, and we make no promises
+    about the stability of any specific HTML structure, CSS variables, etc.
+    Make these customizations at your own risk, and pin versions if you're
+    worried about breaking changes!
+
 .. _custom-css:
 
 Custom CSS Stylesheets

--- a/src/pydata_sphinx_theme/assets/styles/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_base.scss
@@ -40,7 +40,7 @@ a {
     padding: 0 4px 0 4px;
     margin-left: 0.2em;
     text-decoration: none;
-    transition: all 0.3s ease-out;
+    transition: all 0.2s ease-out;
     user-select: none;
 
     &:hover {

--- a/src/pydata_sphinx_theme/assets/styles/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_color.scss
@@ -38,7 +38,6 @@ html[data-theme="light"] {
 
   // headerlinks (the anchors at the end of titles)
   --pst-color-headerlink: rgb(198, 15, 15);
-  --pst-color-headerlink-hover: var(--pst-color-background);
 
   // navigation
   --pst-color-active-navigation: var(--pst-color-primary);
@@ -153,17 +152,17 @@ html[data-theme="dark"] {
   */
 
   // main colors
-  --pst-color-primary: rgb(100, 87, 161);
+  --pst-color-primary: rgb(76, 145, 219);
   --pst-color-success: rgb(72, 135, 87);
-  --pst-color-info: rgb(64, 125, 191); /*23, 162, 184;*/
+  --pst-color-info: rgb(64, 125, 191);
   --pst-color-warning: rgb(193, 162, 69);
   --pst-color-danger: rgb(203, 70, 83);
-  --pst-color-text-base: rgb(245, 245, 245);
+  --pst-color-text-base: rgb(201, 209, 217);
   --pst-color-background: rgb(18, 18, 18);
   --pst-color-background-up: rgb(22, 22, 22); // for 3D effect in dark theme
   --pst-color-background-up-up: rgb(55, 55, 55); // for 3D effects
-  --pst-color-deactivate: rgb(121, 121, 121);
-  --pst-color-border: rgb(140, 140, 140);
+  --pst-color-deactivate: rgb(192, 192, 192);
+  --pst-color-border: var(--pst-color-deactivate);
   --pst-color-shadow: var(--pst-color-background);
 
   // headers
@@ -176,13 +175,12 @@ html[data-theme="dark"] {
   --pst-color-paragraph: var(--pst-color-text-base);
 
   // links
-  --pst-color-link: rgb(64, 98, 191);
+  --pst-color-link: var(--pst-color-primary);
   --pst-color-link-hover: rgb(170, 103, 196);
   --pst-color-target: rgb(117, 148, 195);
 
   // headerlinks (the anchors at the end of titles)
-  --pst-color-headerlink: rgb(152, 61, 61);
-  --pst-color-headerlink-hover: var(--pst-color-background);
+  --pst-color-headerlink: rgb(221, 90, 90);
 
   // navigation
   --pst-color-active-navigation: var(--pst-color-primary);
@@ -193,11 +191,11 @@ html[data-theme="dark"] {
   */
 
   // inline code
-  --pst-color-inline-code: rgb(175, 61, 126);
+  --pst-color-inline-code: rgb(221, 158, 194);
 
   // guilabel
   --pst-color-guilabel-background: rgb(242, 196, 166);
-  --pst-color-guilabel-border: rgb(141, 95, 65);
+  --pst-color-guilabel-border: rgb(83, 56, 38);
   --pst-color-guilabel-text: var(--pst-color-guilabel-border);
 
   // kbd

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -119,9 +119,19 @@ footer {
   input {
     background-color: var(--pst-color-search-background);
     border-radius: 0.2rem;
-    border: 0;
-    border-bottom: 1px solid var(--pst-color-search-border);
+    border: 1px solid var(--pst-color-search-border);
     padding-left: 35px;
+
+    // Inner-text of the search bar
+    &::placeholder {
+      color: var(--pst-color-search);
+    }
+
+    // Background should always be same color regardless of active or nor
+    &:active,
+    &:focus {
+      background-color: var(--pst-color-search-background);
+    }
   }
 }
 
@@ -149,7 +159,7 @@ footer {
 
 .section-nav {
   padding-left: 0;
-  border-left: 1px solid var(--pst-color-toc-link);
+  border-left: 1px solid var(--pst-color-toc-border);
   border-bottom: none;
 
   ul {
@@ -457,10 +467,6 @@ nav.bd-links {
     }
 
     /* Social media buttons */
-    &.fa-github-square:before {
-      color: #333;
-    }
-
     &.fa-twitter-square:before {
       color: #55acee;
     }


### PR DESCRIPTION
I did a few lighthouse tests on the Dark Mode of this theme, and found several areas where it did not pass color contrast tests.

So, this PR makes a number of tweaks to the colors so that (most) of these tests pass. I tried to keep the spirit of the colors the same as much as possible. Where I had to change colors, I just pulled the color that GitHub's dark mode uses.
